### PR TITLE
Add layersOverride option to `public-api-imports` rule

### DIFF
--- a/docs/rules/public-api-imports.md
+++ b/docs/rules/public-api-imports.md
@@ -11,11 +11,12 @@ Auto-fix available.
 ## Rule Options
 
 * `alias`: specify this option if you use aliases.
+* `layersOverride`: specify your own slices names.
 * `testFilesPatterns`: specify regex for import from test files.
 
 ```js
 ...
-"fsd-import/public-api-imports": [<enabled>, { alias: string, testFilesPatterns: array }] 
+"fsd-import/public-api-imports": [<enabled>, { alias: string, layersOverride: array, testFilesPatterns: array }] 
 ...
 ```
 
@@ -58,6 +59,10 @@ import { ISidebarItem } from 'widgets/Sidebar/model/types/sidebar';
 // in MainPage.tsx
 import { ISidebarItem } from '@/widgets/Sidebar/model/types/sidebar';
 
+// "fsd-import/public-api-imports": ["error", { layersOverride: ["_widgets"]}]
+// in MainPage.tsx
+import { ISidebarItem } from '_widgets/Sidebar/model/types/sidebar';
+
 // "fsd-import/public-api-imports": ["error", { alias: "@", testFilesPatterns: ['**/StoreDecorator.tsx'] }]
 // in StoreDecorator.tsx
 import { ISidebarItem } from '@/widgets/Sidebar/model/types/sidebar';
@@ -73,6 +78,10 @@ import { ISidebarItem } from 'widgets/Sidebar';
 // "fsd-import/public-api-imports": ["error", { alias: "@"}]
 // in MainPage.tsx
 import { ISidebarItem } from '@/widgets/Sidebar';
+
+// "fsd-import/public-api-imports": ["error", { layersOverride: ["_widgets"]}]
+// in MainPage.tsx
+import { ISidebarItem } from '_widgets/Sidebar';
 
 // "fsd-import/public-api-imports": ["error", { alias: "@", testFilesPatterns: ['**/StoreDecorator.tsx'] }]
 // in StoreDecorator.tsx

--- a/lib/rules/public-api-imports.js
+++ b/lib/rules/public-api-imports.js
@@ -36,6 +36,12 @@ module.exports = {
                     alias: {
                         type: 'string',
                     },
+                    layersOverride: {
+                        type: "array",
+                        items: { type: "string" },
+                        description:
+                          "Layers that require using public API (default: ['features', 'entities', 'pages', 'widgets'])",
+                    },
                     testFilesPatterns: {
                         type: 'array',
                     },
@@ -45,14 +51,22 @@ module.exports = {
     },
 
     create(context) {
-        const { alias = '', testFilesPatterns = [] } = context.options[0] ?? {};
+        const { alias = '', layersOverride, testFilesPatterns = [] } = context.options[0] ?? {};
 
-        const checkingLayers = {
+        let checkingLayers = {
             'entities': 'entities',
             'features': 'features',
             'pages': 'pages',
             'widgets': 'widgets',
         };
+
+        if (layersOverride?.length) {
+          checkingLayers = layersOverride.reduce((acc, layerOverride) => {
+            if (layerOverride) acc[layerOverride] = layerOverride;
+
+            return acc;
+          }, {})
+        }
 
         //----------------------------------------------------------------------
         // Public

--- a/tests/lib/rules/public-api-imports.js
+++ b/tests/lib/rules/public-api-imports.js
@@ -28,6 +28,17 @@ const aliasOptions = [
     },
 ];
 
+const layersOverride = [
+    'arbitraryLayer'
+];
+
+const layersOverrideOptions = [
+    {
+        layersOverride
+    }
+];
+
+
 ruleTester.run('public-api-imports', rule, {
     valid: [
         {
@@ -38,6 +49,16 @@ ruleTester.run('public-api-imports', rule, {
             code: 'import { addCommentFormActions, addCommentFormReducer } from \'@/entities/Article\';',
             errors: [],
             options: aliasOptions,
+        },
+        {
+            code: `import { addCommentFormActions, addCommentFormReducer } from '${layersOverride[0]}/Article';`,
+            errors: [],
+            options: layersOverrideOptions,
+        },
+        {
+            code: `import { addCommentFormActions, addCommentFormReducer } from '@/${layersOverride[0]}/Article';`,
+            errors: [],
+            options: [{alias: aliasOptions[0].alias, layersOverride: layersOverrideOptions[0].layersOverride}],
         },
         {
             filename: 'C:\\project\\src\\entities\\Article\\file.test.ts',
@@ -82,6 +103,18 @@ ruleTester.run('public-api-imports', rule, {
             errors: [{ message: 'Absolute import is allowed only from public API (index.ts).' }],
             options: aliasOptions,
             output: 'import { addCommentFormActions, addCommentFormReducer } from \'@/entities/Article\';'
+        },
+        {
+            code: `import { addCommentFormActions, addCommentFormReducer } from '${layersOverride[0]}/Article/model/slice/addCommentFormSlice.ts';`,
+            errors: [{ message: 'Absolute import is allowed only from public API (index.ts).' }],
+            options: layersOverrideOptions,
+            output: `import { addCommentFormActions, addCommentFormReducer } from '${layersOverride[0]}/Article';`
+        },
+        {
+            code: `import { addCommentFormActions, addCommentFormReducer } from '@/${layersOverride[0]}/Article/model/slice/addCommentFormSlice.ts';`,
+            errors: [{ message: 'Absolute import is allowed only from public API (index.ts).' }],
+            options: [{alias: aliasOptions[0].alias, layersOverride: layersOverrideOptions[0].layersOverride}],
+            output: `import { addCommentFormActions, addCommentFormReducer } from '@/${layersOverride[0]}/Article';`
         },
         {
             filename: 'C:\\project\\src\\entities\\Article\\StoreDecorator.tsx',


### PR DESCRIPTION
Adds support for overriding layer names with a custom naming scheme

### Description
In some projects, default layer names may conflict with existing tools or instruments.
For example, in my case, I need to prefix layers with an underscore (e.g. _pages) to avoid naming collisions.

### Changes
```js
import fsdImport from 'eslint-plugin-fsd-import';

...
rules: {
  ...
  'fsd-import/public-api-imports': [
    'error',
    {
      alias: '@',
      layersOverride: ['_entities', '_features', '_pages', '_widgets'],
    },
  ],
  ...
}
```
### Motivation / Use cases

- Avoid naming collisions — useful when project setup already uses unprefixed directories (e.g., pages) for other purposes.
- Project conventions — some teams prefer to apply specific prefixes/suffixes to align with their internal naming standards.
- Incremental adoption — makes it easier to introduce this plugin into existing projects without forcing a full directory rename.

### Backwards compatibility
- If layersOverride is not provided, the plugin continues to use the default layer names.
- Existing configurations will remain unaffected.